### PR TITLE
Render all shortcodes, not just ones from this plugin

### DIFF
--- a/includes/engine/class-bnfw-engine.php
+++ b/includes/engine/class-bnfw-engine.php
@@ -550,6 +550,8 @@ class BNFW_Engine {
 			}
 		}
 		$message = preg_replace( '/\[post_term taxonomy="([^"]*)"\]/i', $terms_list, $message );
+		
+		$message = do_shortcode( $message );
 
 		return apply_filters( 'bnfw_shortcodes_post', $message, $post_id );
 	}


### PR DESCRIPTION
Post content now supports rendering shortcodes from all plugins, not just the pseudo-shortcodes (string replacements) used by this plugin. Example use case: https://theeventscalendar.com/support/forums/topic/display-event-start-and-end-dates-in-an-email-using-the-bnfw/#post-1243308