### PR TITLE
Add filters for the $args and $posts on the WP_Query objects

### DIFF
--- a/includes/admin/class-bnfw-notification.php
+++ b/includes/admin/class-bnfw-notification.php
@@ -1000,8 +1000,12 @@ foreach ( $taxs as $tax ) {
 		$args['posts_per_page'] = -1;
 		$args['nopagging'] = true;
 
+		$args = apply_filters( 'bnfw_get_notifications_args', $args, $types, $exclude_disabled );
+
 		$wp_query = new WP_Query();
 		$posts    = $wp_query->query( $args );
+
+		$posts = apply_filters( 'bnfw_get_notifications_posts', $posts, $args, $types, $exclude_disabled );
 
 		return $posts;
 	}
@@ -1031,8 +1035,12 @@ foreach ( $taxs as $tax ) {
 			)
 		);
 
+		$args = apply_filters( 'bnfw_is_notification_disabled_args', $args, $type );
+
 		$wp_query = new WP_Query();
 		$posts    = $wp_query->query( $args );
+
+		$posts = apply_filters( 'bnfw_is_notification_disabled_posts', $posts, $args, $type );
 
 		return count( $posts ) > 0;
 	}


### PR DESCRIPTION
Currently the only way to filter the arguments of the custom queries is to hook into the `pre_get_posts` filter, for example:

```php
add_action( 'pre_get_posts', function ( $query ) {
    if ( $query->query_vars['post_type'] === 'bnfw_notification' ) {
        //
    }
} );
```

The `bnfw_get_notifications_args` and `bnfw_is_notification_disabled_args` would make this a more pleasent experience.

----

The `bnfw_get_notifications_posts` and `bnfw_is_notification_disabled_posts` would allow the possibility to filter the retrieved posts. This is useful when there are multiple notifications for one event. 

Some notifications, like the `user-password` does not send all potential notifications, but only the last one in the list. The new filters would allow us some fine-grained control as they are prefiltering the possible notifications.